### PR TITLE
[FEAT] 시간별 불꽃 길이 계산

### DIFF
--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -10,14 +10,16 @@ import useInterval from '../util/useInterval';
 const DECI_SEC = 100;
 const DEV_OFFSET = 91; // margin-left: 91px
 const DINO_CONTAINER = 711;
-const DEV_CONTAINER = 711 - DEV_OFFSET;
+const DEV_CONTAINER = DINO_CONTAINER - DEV_OFFSET;
 const DINO_1_PER = DINO_CONTAINER * 0.01;
 const DEV_1_PER = DEV_CONTAINER * 0.01;
 const DINO_WIDTH = 40;
-const FIRE_WIDTH = 40;
+const FIRE_DURATION = 700;
+const FIRE_1_FRAME_MS = FIRE_DURATION / 4;
+const FIRE_WIDTH = [13, 20, 27, 40];
 const GAME_OVER_GAP = {
   NORMAL: DINO_WIDTH,
-  FIRE: DINO_WIDTH + FIRE_WIDTH,
+  FIRE: FIRE_WIDTH.map((w, i) => DINO_WIDTH + FIRE_WIDTH[i]),
 };
 const FEVER_DURATION = 3000;
 const FEVER_THRESHOLD = 15;
@@ -37,6 +39,7 @@ function Game() {
   const [dinoSpeed, setDinoSpeed] = useState(150);
   const [dinoPos, setDinoPos] = useState(0);
   const [isFire, setIsFire] = useState(false);
+  const [onFireTime, setOnFireTime] = useState(0);
   const [isFever, setIsFever] = useState(false);
   const [isEnd, setIsEnd] = useState({ isEnd: false, type: null });
 
@@ -62,9 +65,10 @@ function Game() {
     if (wrong === 0) return;
     if (wrong % 5 === 0) {
       setIsFire(true);
+      setOnFireTime(new Date());
       setTimeout(() => {
         setIsFire(false);
-      }, 700);
+      }, FIRE_DURATION);
     }
   }, [wrong]);
 
@@ -125,8 +129,11 @@ function Game() {
 
   useEffect(() => {
     if (isEnd.isEnd === true) return;
+    const timeDiff = new Date() - onFireTime;
+    const fireLength =
+      timeDiff <= FIRE_DURATION ? GAME_OVER_GAP.FIRE[Math.floor(timeDiff / FIRE_1_FRAME_MS)] : GAME_OVER_GAP.FIRE[3];
     const isGameOver =
-      progress * DEV_1_PER + DEV_OFFSET - dinoPos * DINO_1_PER <= (isFire ? GAME_OVER_GAP.FIRE : GAME_OVER_GAP.NORMAL);
+      progress * DEV_1_PER + DEV_OFFSET - dinoPos * DINO_1_PER <= (isFire ? fireLength : GAME_OVER_GAP.NORMAL);
     if (progress === 100) {
       setIsEnd({ isEnd: true, type: 'clear' });
     } else if (isGameOver) {


### PR DESCRIPTION
<!--
  PR 작성 가이드
1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
2. emoji, @어노테이션 등을 사용하여 효과적으로 소통할 것.
3. 명확하게 질문하고 명확하게 답변할 것.
4. 새로운 모듈 설치시 PR message에 기재할 것.
5. PR 올리기전에 branch 반드시 확인할 것. 
-->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
- 시간별 불꽃 길이 계산
## 👩‍💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 기존에 불꽃 길이 변화를 고려하지 않고 불꽃의 최대 길이로 게임 종료를 판단하고 있어서 불꽃이 닿지 않았는데 캐릭터가 죽는 문제가 발생했습니다.
- onFireTime에 불꽃이 발사된 시간을 저장합니다.
- FIRE_WIDTH에 시간별 불꽃의 길이를 저장하고, 그를 활용하여 GAME_OVER_GAP.FIRE를 정합니다.

